### PR TITLE
bugfixes for Dockerrun.aws.json:

### DIFF
--- a/4.ci_cd_multi_container/Dockerrun.aws.json
+++ b/4.ci_cd_multi_container/Dockerrun.aws.json
@@ -5,14 +5,15 @@
       "name": "api",
       "image": "dennistimmers/multi_api",
       "hostname": "api",
-      "essential": false
+      "essential": false,
+      "memory": 128
     },
     {
       "name": "client",
       "image": "dennistimmers/multi_client",
       "hostname": "client",
       "essential": false,
-      "links": ["nginx"]
+      "memory": 128
     },
     {
       "name": "nginx",
@@ -25,13 +26,15 @@
           "containerPort": 80
         }
       ],
-      "links": ["api", "client"]
+      "links": ["api", "client"],
+      "memory": 128
     },
     {
       "name": "worker",
       "image": "dennistimmers/multi_worker",
       "hostname": "worker",
-      "essential": false
+      "essential": false,
+      "memory": 128
     }
   ]
 }


### PR DESCRIPTION
1. avoid cycles with links
2. add memory allocation to containers